### PR TITLE
Feature/lector carreras

### DIFF
--- a/routes/lector.php
+++ b/routes/lector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Lectores\Controllers\LectorController;
+use App\Lectores\Repositories\CarreraRepository;
 use App\Lectores\Repositories\LectorRepository;
 use App\Lectores\Services\LectorService;
 
@@ -11,9 +12,18 @@ use App\Lectores\Services\LectorService;
  */
 
 $lectorRepository = new LectorRepository();
-$lectorService = new LectorService($lectorRepository);
+$carreraRepository = new CarreraRepository();
+$lectorService = new LectorService($lectorRepository, $carreraRepository);
 $lectorController = new LectorController($lectorService);
 
 $router->get("/lectores/mi-perfil", function () use ($lectorController) {
     $lectorController->getMiPerfil();
+});
+
+$router->post("/lectores/{lectorId}/carreras/{carreraId}", function ($lectorId, $carreraId) use ($lectorController) {
+    $lectorController->assignCarrera($lectorId, $carreraId);
+});
+
+$router->delete("/lectores/{lectorId}/carreras/{carreraId}", function ($lectorId, $carreraId) use ($lectorController) {
+    $lectorController->removeCarrera($lectorId, $carreraId);
 });

--- a/src/Lectores/Controllers/LectorController.php
+++ b/src/Lectores/Controllers/LectorController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Lectores\Controllers;
 
 use App\Lectores\Services\LectorService;
+use App\Lectores\Validators\LectorRequestValidator;
 use App\Shared\Http\JsonHelper;
 use OpenApi\Attributes as OA;
 
@@ -43,5 +44,82 @@ class LectorController
         $perfil = $this->lectorService->getPerfil($userId, $dni);
 
         JsonHelper::jsonResponse(['data' => $perfil], 200);
+    }
+
+    #[OA\Post(
+        path: "/lectores/{lectorId}/carreras/{carreraId}",
+        description: "Asigna una carrera a un lector",
+        summary: "Asignar carrera a lector",
+        security: [["bearerAuth" => []]],
+        tags: ["Lectores"],
+        parameters: [
+            new OA\Parameter(
+                name: "lectorId",
+                in: "path",
+                description: "ID del lector",
+                required: true,
+                schema: new OA\Schema(type: "integer")
+            ),
+            new OA\Parameter(
+                name: "carreraId",
+                in: "path",
+                description: "ID de la carrera",
+                required: true,
+                schema: new OA\Schema(type: "integer")
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 201, description: "Carrera asignada exitosamente"),
+            new OA\Response(response: 400, description: "Datos inválidos"),
+            new OA\Response(response: 404, description: "Lector o carrera no encontrados"),
+            new OA\Response(response: 409, description: "La carrera ya está asignada"),
+            new OA\Response(response: 500, description: "Error interno del servidor"),
+        ]
+    )]
+    public function assignCarrera(string $lectorId, string $carreraId): void
+    {
+        LectorRequestValidator::validateId($lectorId, 'lectorId');
+        LectorRequestValidator::validateId($carreraId, 'carreraId');
+
+        $this->lectorService->assignCarrera((int) $lectorId, (int) $carreraId);
+        http_response_code(201);
+    }
+
+    #[OA\Delete(
+        path: "/lectores/{lectorId}/carreras/{carreraId}",
+        description: "Quita una carrera asignada a un lector",
+        summary: "Quitar carrera de lector",
+        security: [["bearerAuth" => []]],
+        tags: ["Lectores"],
+        parameters: [
+            new OA\Parameter(
+                name: "lectorId",
+                in: "path",
+                description: "ID del lector",
+                required: true,
+                schema: new OA\Schema(type: "integer")
+            ),
+            new OA\Parameter(
+                name: "carreraId",
+                in: "path",
+                description: "ID de la carrera",
+                required: true,
+                schema: new OA\Schema(type: "integer")
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: "Carrera quitada exitosamente"),
+            new OA\Response(response: 400, description: "Datos inválidos"),
+            new OA\Response(response: 404, description: "Lector o carrera no encontrados"),
+            new OA\Response(response: 500, description: "Error interno del servidor"),
+        ]
+    )]
+    public function removeCarrera(string $lectorId, string $carreraId): void
+    {
+        LectorRequestValidator::validateId($lectorId, 'lectorId');
+        LectorRequestValidator::validateId($carreraId, 'carreraId');
+
+        $this->lectorService->removeCarrera((int) $lectorId, (int) $carreraId);
+        http_response_code(204);
     }
 }

--- a/src/Lectores/Controllers/LectorController.php
+++ b/src/Lectores/Controllers/LectorController.php
@@ -108,9 +108,10 @@ class LectorController
             ),
         ],
         responses: [
-            new OA\Response(response: 204, description: "Carrera quitada exitosamente"),
+            new OA\Response(response: 200, description: "Carrera quitada exitosamente"),
             new OA\Response(response: 400, description: "Datos inválidos"),
             new OA\Response(response: 404, description: "Lector o carrera no encontrados"),
+            new OA\Response(response: 409, description: "La carrera no está asignada al lector"),
             new OA\Response(response: 500, description: "Error interno del servidor"),
         ]
     )]
@@ -120,6 +121,6 @@ class LectorController
         LectorRequestValidator::validateId($carreraId, 'carreraId');
 
         $this->lectorService->removeCarrera((int) $lectorId, (int) $carreraId);
-        http_response_code(204);
+        JsonHelper::jsonResponse(['message' => 'La carrera ha sido quitada del lector'], 200);
     }
 }

--- a/src/Lectores/Controllers/LectorController.php
+++ b/src/Lectores/Controllers/LectorController.php
@@ -69,7 +69,13 @@ class LectorController
             ),
         ],
         responses: [
-            new OA\Response(response: 201, description: "Carrera asignada exitosamente"),
+            new OA\Response(
+                response: 201,
+                description: "Carrera asignada exitosamente",
+                content: new OA\JsonContent(
+                    properties: [new OA\Property(property: "message", type: "string")]
+                )
+            ),
             new OA\Response(response: 400, description: "Datos inválidos"),
             new OA\Response(response: 404, description: "Lector o carrera no encontrados"),
             new OA\Response(response: 409, description: "La carrera ya está asignada"),
@@ -82,7 +88,7 @@ class LectorController
         LectorRequestValidator::validateId($carreraId, 'carreraId');
 
         $this->lectorService->assignCarrera((int) $lectorId, (int) $carreraId);
-        http_response_code(201);
+        JsonHelper::jsonResponse(['message' => 'La carrera ha sido asignada al lector'], 201);
     }
 
     #[OA\Delete(

--- a/src/Lectores/Dtos/Response/LectorPerfilResponse.php
+++ b/src/Lectores/Dtos/Response/LectorPerfilResponse.php
@@ -13,6 +13,9 @@ use OpenApi\Attributes as OA;
 )]
 readonly class LectorPerfilResponse implements JsonSerializable
 {
+    /**
+     * @param string[] $carreras
+     */
     public function __construct(
         #[OA\Property(type: "string", example: "Juan")]
         private string $nombre,
@@ -28,6 +31,8 @@ readonly class LectorPerfilResponse implements JsonSerializable
         private string $telefono,
         #[OA\Property(type: "string", example: "juan@example.com")]
         private string $email,
+        #[OA\Property(type: "array", example: ["Contador Público", "Abogacía"])]
+        private array $carreras,
     ) {
     }
 
@@ -41,6 +46,7 @@ readonly class LectorPerfilResponse implements JsonSerializable
             'legajo' => $this->legajo,
             'telefono' => $this->telefono,
             'email' => $this->email,
+            'carreras' => $this->carreras,
         ];
     }
 }

--- a/src/Lectores/Exceptions/LectorCarreraAlreadyAssignedException.php
+++ b/src/Lectores/Exceptions/LectorCarreraAlreadyAssignedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lectores\Exceptions;
+
+use App\Shared\Exceptions\AlreadyExistsException;
+
+class LectorCarreraAlreadyAssignedException extends AlreadyExistsException
+{
+    public function __construct()
+    {
+        parent::__construct('La carrera ya esta asignada al lector');
+    }
+}

--- a/src/Lectores/Exceptions/LectorCarreraNotAssignedException.php
+++ b/src/Lectores/Exceptions/LectorCarreraNotAssignedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lectores\Exceptions;
+
+use App\Shared\Exceptions\NotFoundException;
+
+class LectorCarreraNotAssignedException extends NotFoundException
+{
+    public function __construct()
+    {
+        parent::__construct('La carrera no esta asignada al lector');
+    }
+}

--- a/src/Lectores/Exceptions/LectorCarreraNotAssignedException.php
+++ b/src/Lectores/Exceptions/LectorCarreraNotAssignedException.php
@@ -4,12 +4,27 @@ declare(strict_types=1);
 
 namespace App\Lectores\Exceptions;
 
-use App\Shared\Exceptions\NotFoundException;
+use App\Shared\Exceptions\AppException;
 
-class LectorCarreraNotAssignedException extends NotFoundException
+class LectorCarreraNotAssignedException extends AppException
 {
     public function __construct()
     {
         parent::__construct('La carrera no esta asignada al lector');
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'LECTOR_CARRERA_NOT_ASSIGNED';
+    }
+
+    public function getHttpStatus(): int
+    {
+        return 409;
+    }
+
+    public function getSafeMessage(): string
+    {
+        return $this->getMessage();
     }
 }

--- a/src/Lectores/Repositories/LectorRepository.php
+++ b/src/Lectores/Repositories/LectorRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Lectores\Repositories;
 
+use App\Lectores\Models\Carrera;
 use App\Lectores\Models\Lector;
 use App\Shared\Repository;
 
@@ -57,6 +58,89 @@ class LectorRepository extends Repository
     public function findByUserId(int $userId): ?Lector
     {
         $sql = "SELECT * FROM {$this->getTableName()} WHERE user_id = :user_id LIMIT 1";
-        return $this->findOneByQuery($sql, ['user_id' => $userId]);
+        /** @var ?Lector $lector */
+        $lector = $this->findOneByQuery($sql, ['user_id' => $userId]);
+
+        if ($lector === null) {
+            return null;
+        }
+
+        $lector->setCarreras($this->findCarrerasByLectorId($lector->getId()));
+
+        return $lector;
+    }
+
+    /**
+     * @return Carrera[]
+     */
+    public function findCarrerasByLectorId(int $lectorId): array
+    {
+        $sql = "
+            SELECT c.*
+            FROM carrera c
+            INNER JOIN lector_carrera lc ON lc.carrera_id = c.id
+            WHERE lc.lector_id = :lector_id
+            ORDER BY c.nombre
+        ";
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(['lector_id' => $lectorId]);
+
+        $carreras = [];
+        while ($row = $stmt->fetch()) {
+            $carreras[] = Carrera::fromDatabase($row);
+        }
+
+        return $carreras;
+    }
+
+    public function hasCarrera(int $lectorId, int $carreraId): bool
+    {
+        $sql = "
+            SELECT 1
+            FROM lector_carrera
+            WHERE lector_id = :lector_id AND carrera_id = :carrera_id
+            LIMIT 1
+        ";
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([
+            'lector_id' => $lectorId,
+            'carrera_id' => $carreraId,
+        ]);
+
+        return $stmt->fetch() !== false;
+    }
+
+    public function assignCarrera(int $lectorId, int $carreraId): bool
+    {
+        $sql = '
+            INSERT INTO lector_carrera (lector_id, carrera_id)
+            VALUES (:lector_id, :carrera_id)
+        ';
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([
+            'lector_id' => $lectorId,
+            'carrera_id' => $carreraId,
+        ]);
+
+        return $stmt->rowCount() > 0;
+    }
+
+    public function removeCarrera(int $lectorId, int $carreraId): bool
+    {
+        $sql = '
+            DELETE FROM lector_carrera
+            WHERE lector_id = :lector_id AND carrera_id = :carrera_id
+        ';
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([
+            'lector_id' => $lectorId,
+            'carrera_id' => $carreraId,
+        ]);
+
+        return $stmt->rowCount() > 0;
     }
 }

--- a/src/Lectores/Services/LectorService.php
+++ b/src/Lectores/Services/LectorService.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace App\Lectores\Services;
 
 use App\Lectores\Dtos\Response\LectorPerfilResponse;
+use App\Lectores\Exceptions\LectorCarreraAlreadyAssignedException;
+use App\Lectores\Exceptions\LectorCarreraNotAssignedException;
+use App\Lectores\Repositories\CarreraRepository;
 use App\Lectores\Repositories\LectorRepository;
 use App\Shared\Exceptions\NotFoundException;
 
 class LectorService
 {
-    public function __construct(private readonly LectorRepository $lectorRepository)
-    {
+    public function __construct(
+        private readonly LectorRepository $lectorRepository,
+        private readonly CarreraRepository $carreraRepository
+    ) {
     }
 
     public function getPerfil(int $userId, string $dni): LectorPerfilResponse
@@ -22,6 +27,11 @@ class LectorService
             throw new NotFoundException('Lector no encontrado');
         }
 
+        $carreras = array_map(
+            static fn($carrera) => $carrera->getNombre(),
+            $lector->getCarreras()
+        );
+
         return new LectorPerfilResponse(
             $lector->getNombre(),
             $lector->getApellido(),
@@ -30,6 +40,41 @@ class LectorService
             $lector->getLegajo(),
             $lector->getTelefono(),
             $lector->getEmail(),
+            $carreras,
         );
+    }
+
+    public function assignCarrera(int $lectorId, int $carreraId): void
+    {
+        if ($this->lectorRepository->findById($lectorId) === null) {
+            throw new NotFoundException('Lector no encontrado');
+        }
+
+        if ($this->carreraRepository->findById($carreraId) === null) {
+            throw new NotFoundException('Carrera no encontrada');
+        }
+
+        if ($this->lectorRepository->hasCarrera($lectorId, $carreraId)) {
+            throw new LectorCarreraAlreadyAssignedException();
+        }
+
+        $this->lectorRepository->assignCarrera($lectorId, $carreraId);
+    }
+
+    public function removeCarrera(int $lectorId, int $carreraId): void
+    {
+        if ($this->lectorRepository->findById($lectorId) === null) {
+            throw new NotFoundException('Lector no encontrado');
+        }
+
+        if ($this->carreraRepository->findById($carreraId) === null) {
+            throw new NotFoundException('Carrera no encontrada');
+        }
+
+        if (!$this->lectorRepository->hasCarrera($lectorId, $carreraId)) {
+            throw new LectorCarreraNotAssignedException();
+        }
+
+        $this->lectorRepository->removeCarrera($lectorId, $carreraId);
     }
 }

--- a/src/Lectores/Validators/LectorRequestValidator.php
+++ b/src/Lectores/Validators/LectorRequestValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lectores\Validators;
+
+use App\Shared\Exceptions\ValidationException;
+
+class LectorRequestValidator
+{
+    public static function validateId(string $id, string $field): void
+    {
+        $errors = [];
+
+        if (!is_numeric($id)) {
+            $errors[$field] = ["El campo {$field} debe ser un numero"];
+        } elseif ((int) $id < 1) {
+            $errors[$field] = ["El campo {$field} debe ser un entero positivo mayor a 0"];
+        }
+
+        if (!ctype_digit($id)) {
+            $errors[$field] = ["El campo {$field} debe ser un numero valido"];
+        }
+
+        if (!empty($errors)) {
+            throw new ValidationException($errors);
+        }
+    }
+}

--- a/tests/Unit/Lectores/Services/LectorServiceTest.php
+++ b/tests/Unit/Lectores/Services/LectorServiceTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Lectores\Dtos\Response\LectorPerfilResponse;
+use App\Lectores\Exceptions\LectorCarreraAlreadyAssignedException;
+use App\Lectores\Exceptions\LectorCarreraNotAssignedException;
+use App\Lectores\Models\Carrera;
+use App\Lectores\Models\Lector;
+use App\Lectores\Repositories\CarreraRepository;
+use App\Lectores\Repositories\LectorRepository;
+use App\Lectores\Services\LectorService;
+use App\Shared\Exceptions\NotFoundException;
+
+beforeEach(function () {
+    $this->lectorRepository = Mockery::mock(LectorRepository::class);
+    $this->carreraRepository = Mockery::mock(CarreraRepository::class);
+    $this->service = new LectorService($this->lectorRepository, $this->carreraRepository);
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('getPerfil devuelve el lector con carreras como arreglo de strings', function () {
+    $lector = Lector::create(
+        '123456',
+        1,
+        'Juan',
+        'Perez',
+        new DateTimeImmutable('2000-01-01'),
+        '2616123456',
+        'juan@example.com',
+        'K1234',
+        'M',
+        null
+    );
+    $lector->setCarreras([
+        Carrera::create('PSI', 'Psicologia'),
+        Carrera::create('DER', 'Derecho'),
+    ]);
+
+    $this->lectorRepository
+        ->shouldReceive('findByUserId')
+        ->once()
+        ->with(1)
+        ->andReturn($lector);
+
+    $response = $this->service->getPerfil(1, '12345678');
+
+    expect($response)->toBeInstanceOf(LectorPerfilResponse::class)
+        ->and($response->jsonSerialize()['carreras'])->toBe(['Psicologia', 'Derecho'])
+        ->and($response->jsonSerialize()['dni'])->toBe('12345678');
+});
+
+test('getPerfil lanza NotFoundException si el lector no existe', function () {
+    $this->lectorRepository
+        ->shouldReceive('findByUserId')
+        ->once()
+        ->with(1)
+        ->andReturnNull();
+
+    expect(fn () => $this->service->getPerfil(1, '12345678'))
+        ->toThrow(NotFoundException::class, 'Lector no encontrado');
+});
+
+test('assignCarrera asigna una carrera al lector', function () {
+    $lector = Lector::create(
+        '123456',
+        1,
+        'Juan',
+        'Perez',
+        new DateTimeImmutable('2000-01-01'),
+        '2616123456',
+        'juan@example.com'
+    );
+    $lector->setId(1);
+
+    $carrera = Carrera::create('PSI', 'Psicologia');
+    $carrera->setId(2);
+
+    $this->lectorRepository
+        ->shouldReceive('findById')
+        ->with(1)
+        ->once()
+        ->andReturn($lector);
+
+    $this->carreraRepository
+        ->shouldReceive('findById')
+        ->with(2)
+        ->once()
+        ->andReturn($carrera);
+
+    $this->lectorRepository
+        ->shouldReceive('hasCarrera')
+        ->with(1, 2)
+        ->once()
+        ->andReturn(false);
+
+    $this->lectorRepository
+        ->shouldReceive('assignCarrera')
+        ->with(1, 2)
+        ->once()
+        ->andReturnTrue();
+
+    $this->service->assignCarrera(1, 2);
+
+    expect(true)->toBeTrue();
+});
+
+test('assignCarrera lanza conflicto si la carrera ya estaba asignada', function () {
+    $lector = Lector::create(
+        '123456',
+        1,
+        'Juan',
+        'Perez',
+        new DateTimeImmutable('2000-01-01'),
+        '2616123456',
+        'juan@example.com'
+    );
+    $lector->setId(1);
+
+    $carrera = Carrera::create('PSI', 'Psicologia');
+    $carrera->setId(2);
+
+    $this->lectorRepository
+        ->shouldReceive('findById')
+        ->with(1)
+        ->once()
+        ->andReturn($lector);
+
+    $this->carreraRepository
+        ->shouldReceive('findById')
+        ->with(2)
+        ->once()
+        ->andReturn($carrera);
+
+    $this->lectorRepository
+        ->shouldReceive('hasCarrera')
+        ->with(1, 2)
+        ->once()
+        ->andReturn(true);
+
+    expect(fn () => $this->service->assignCarrera(1, 2))
+        ->toThrow(LectorCarreraAlreadyAssignedException::class);
+});
+
+test('removeCarrera quita una carrera del lector', function () {
+    $lector = Lector::create(
+        '123456',
+        1,
+        'Juan',
+        'Perez',
+        new DateTimeImmutable('2000-01-01'),
+        '2616123456',
+        'juan@example.com'
+    );
+    $lector->setId(1);
+
+    $carrera = Carrera::create('PSI', 'Psicologia');
+    $carrera->setId(2);
+
+    $this->lectorRepository
+        ->shouldReceive('findById')
+        ->with(1)
+        ->once()
+        ->andReturn($lector);
+
+    $this->carreraRepository
+        ->shouldReceive('findById')
+        ->with(2)
+        ->once()
+        ->andReturn($carrera);
+
+    $this->lectorRepository
+        ->shouldReceive('hasCarrera')
+        ->with(1, 2)
+        ->once()
+        ->andReturn(true);
+
+    $this->lectorRepository
+        ->shouldReceive('removeCarrera')
+        ->with(1, 2)
+        ->once()
+        ->andReturnTrue();
+
+    $this->service->removeCarrera(1, 2);
+
+    expect(true)->toBeTrue();
+});
+
+test('removeCarrera lanza conflicto si la carrera no estaba asignada', function () {
+    $lector = Lector::create(
+        '123456',
+        1,
+        'Juan',
+        'Perez',
+        new DateTimeImmutable('2000-01-01'),
+        '2616123456',
+        'juan@example.com'
+    );
+    $lector->setId(1);
+
+    $carrera = Carrera::create('PSI', 'Psicologia');
+    $carrera->setId(2);
+
+    $this->lectorRepository
+        ->shouldReceive('findById')
+        ->with(1)
+        ->once()
+        ->andReturn($lector);
+
+    $this->carreraRepository
+        ->shouldReceive('findById')
+        ->with(2)
+        ->once()
+        ->andReturn($carrera);
+
+    $this->lectorRepository
+        ->shouldReceive('hasCarrera')
+        ->with(1, 2)
+        ->once()
+        ->andReturn(false);
+
+    expect(fn () => $this->service->removeCarrera(1, 2))
+        ->toThrow(LectorCarreraNotAssignedException::class);
+});


### PR DESCRIPTION
This pull request adds functionality for assigning and removing "carreras" (academic programs) to and from "lectores" (readers), including API endpoints, service logic, repository methods, validation, exceptions, and corresponding unit tests. It also updates the lector profile response to include the list of assigned carreras.

Key changes include:

**API and Controller Enhancements**
* Added new POST and DELETE endpoints to assign and remove carreras for a lector in `routes/lector.php`, and implemented corresponding controller methods with OpenAPI documentation in `LectorController`. These endpoints validate input and return appropriate status codes and messages. [[1]](diffhunk://#diff-dc92954db628e951ec7c82fd8dcf9107ca4390714fc42fc51b61fd733a993139L14-R29) [[2]](diffhunk://#diff-ec91bdafaf6c1d8d4c1808c79b8418716cb281b496588601019504172e7f4c27R48-R131)

**Service and Business Logic**
* Updated `LectorService` to support assigning and removing carreras, including checks for existence and assignment state, and to throw custom exceptions for conflict and not found scenarios. The service now also injects a `CarreraRepository`. [[1]](diffhunk://#diff-e9ecb581637b30bf97f6a8521e7ea2e8f69077a3ad3500c85caf49ffd306912bR8-R19) [[2]](diffhunk://#diff-e9ecb581637b30bf97f6a8521e7ea2e8f69077a3ad3500c85caf49ffd306912bR43-R79)

**Repository Layer**
* Extended `LectorRepository` with methods to find carreras by lector, check if a carrera is assigned, and assign or remove carreras. The repository now loads carreras when fetching a lector.

**Validation and Exception Handling**
* Added `LectorRequestValidator` for validating lector and carrera IDs in requests, and custom exceptions for already assigned and not assigned cases. [[1]](diffhunk://#diff-d9860526459e5c6bac973e8b990d37d7cc1f667e5fd67a30e6f512572a3c58baR1-R29) [[2]](diffhunk://#diff-7aadd399b8ac6d3e015aa11c98d7afdfbd44b2103ed88fb29fd052ca8520cc55R1-R15) [[3]](diffhunk://#diff-4680617268bf4b78ff72a228796261cc9ed77b254cf427316b4616173debf7e4R1-R30)

**DTO and Response Updates**
* Modified `LectorPerfilResponse` to include an array of carrera names, and updated the service to provide this data. [[1]](diffhunk://#diff-b6f41d7f037b3fdc37246af608cebaed34595a9e897b565e9c314e59ecbac06aR16-R18) [[2]](diffhunk://#diff-b6f41d7f037b3fdc37246af608cebaed34595a9e897b565e9c314e59ecbac06aR34-R35) [[3]](diffhunk://#diff-e9ecb581637b30bf97f6a8521e7ea2e8f69077a3ad3500c85caf49ffd306912bR30-R34) [[4]](diffhunk://#diff-b6f41d7f037b3fdc37246af608cebaed34595a9e897b565e9c314e59ecbac06aR49)

**Testing**
* Added comprehensive unit tests for the new service methods, including success and error scenarios for assigning and removing carreras.