### PR TITLE
fix: usar USER_LECTOR_ID en lugar de USER_ID en getMisReservas

### DIFF
--- a/src/Circulacion/Controllers/ReservaController.php
+++ b/src/Circulacion/Controllers/ReservaController.php
@@ -183,7 +183,7 @@ readonly class ReservaController
     )]
     public function getMisReservas(): void
     {
-        $lectorId = (int) $_SERVER['USER_ID'];
+        $lectorId = (int) $_SERVER['USER_LECTOR_ID'];
         $page = isset($_GET['page']) ? (int) $_GET['page'] : 1;
         $perPage = isset($_GET['per_page']) ? (int) $_GET['per_page'] : 10;
         $estado = $this->parseEstado($_GET['estado'] ?? null);


### PR DESCRIPTION
This pull request makes a small update to the way the user ID is retrieved in the `getMisReservas` method of the `ReservaController`. The code now uses the `USER_LECTOR_ID` server variable instead of `USER_ID` to get the current user's identifier.

- Changed the user identifier source in `getMisReservas` from `$_SERVER['USER_ID']` to `$_SERVER['USER_LECTOR_ID']` for more accurate user resolution. (`src/Circulacion/Controllers/ReservaController.php`)